### PR TITLE
Allow importing dist/

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     ".": {
       "import": "./dist/vue-pivottable.mjs",
       "require": "./dist/vue-pivottable.umd.js"
-    }
+    },
+    "./dist/": "./dist/"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This to prevent Webpack from erroring out when we try to import the CSS, as reported in #74.